### PR TITLE
Fix errors when converting flac and opus.

### DIFF
--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -138,17 +138,21 @@ class NIStemFile:
                 for i in range(4)
             ]
 
-        src = tagpy.FileRef(src)
-        dst = tagpy.FileRef(self.__path)
+        try:
+            src = tagpy.FileRef(src)
+        except ValueError as e:
+            print(f"ERROR: Unable to read source tags: {e}")
+        else:
+            dst = tagpy.FileRef(self.__path)
 
-        src_tag = src.tag()
-        dst_tag = dst.tag()
-        for tag in SUPPORTED_TAGS:
-            setattr(dst_tag, tag, getattr(src_tag, tag))
+            src_tag = src.tag()
+            dst_tag = dst.tag()
+            for tag in SUPPORTED_TAGS:
+                setattr(dst_tag, tag, getattr(src_tag, tag))
 
-        cover = _extract_cover(src)
-        if cover:
-            c = tagpy.mp4.CoverArtList()
-            c.append(cover)
-            dst_tag.covers = c
-        dst.save()
+            cover = _extract_cover(src)
+            if cover:
+                c = tagpy.mp4.CoverArtList()
+                c.append(cover)
+                dst_tag.covers = c
+            dst.save()

--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -30,7 +30,7 @@ def _extract_cover(f):
         covers = tag.covers
     elif hasattr(tag, "pictureList"):
         covers = tag.pictureList()
-    elif hasattr(f, "ID3v2Tag"):
+    elif hasattr(f, "ID3v2Tag") and f.ID3v2Tag():
         covers = [
             a
             for a in f.ID3v2Tag().frameList()


### PR DESCRIPTION
I had these 2 issues when converting flac and opus. Both were related to metadata and the actual stem creation succeeded. This patchset avoids these exceptions.