### PR TITLE
Add ability to encode flac+opus and some minor improvements.

### DIFF
--- a/stemgen/__main__.py
+++ b/stemgen/__main__.py
@@ -237,7 +237,7 @@ def generate(
         original, stems = None, []
 
         with click.progressbar(
-            length=samples.shape[1] * len(demucs.weights),
+            length=demucs.length(samples) * shifts,
             show_eta=True,
             show_percent=True,
             label="Demucsing",

--- a/stemgen/__main__.py
+++ b/stemgen/__main__.py
@@ -10,6 +10,7 @@ from .cli import (
     validate_model,
     validate_stem_label,
     validate_stem_color,
+    validate_sample_rate_for_codec,
     print_version,
     print_supported_models,
     enable_verbose_ffmpeg_log_level,
@@ -37,12 +38,14 @@ def common_options(func):
     @click.option(
         "--codec",
         default=Codec.AAC,
+        callback=validate_sample_rate_for_codec,
         help="The codec to use for the stem stream stored in the output MP4.",
         type=click.Choice(Codec, case_sensitive=False),
     )
     @click.option(
         "--sample-rate",
         default=str(SampleRate.Hz44100),
+        callback=validate_sample_rate_for_codec,
         help="The sample rate to use for the output.",
         type=click.Choice([str(s.value) for s in SampleRate]),
     )

--- a/stemgen/__main__.py
+++ b/stemgen/__main__.py
@@ -17,6 +17,7 @@ from .cli import (
 from .demucs import Demucs
 from .track import Track
 from .nistemfile import NIStemFile
+from .constant import Codec
 
 
 def common_options(func):
@@ -34,9 +35,10 @@ def common_options(func):
         help="Display verbose information which may be useful for debugging",
     )
     @click.option(
-        "--use-alac/--use-aac",
-        default=False,
+        "--codec",
+        default=Codec.AAC,
         help="The codec to use for the stem stream stored in the output MP4.",
+        type=click.Choice(Codec, case_sensitive=False),
     )
     @click.option(
         "--drum-stem-label",
@@ -190,7 +192,7 @@ def generate(
     shifts,
     overlap,
     jobs,
-    use_alac,
+    codec,
     drum_stem_label,
     drum_stem_color,
     bass_stem_label,
@@ -257,7 +259,7 @@ def generate(
                         f"\t{warnings._formatwarnmsg_impl(message)}", fg="yellow"
                     )
 
-        out = NIStemFile(dst, use_alac=use_alac)
+        out = NIStemFile(dst, codec)
         out.write(original, stems)
         out.update_metadata(
             file,
@@ -327,7 +329,7 @@ def create(
     vocal,
     force,
     verbose,
-    use_alac,
+    codec,
     drum_stem_label,
     drum_stem_color,
     bass_stem_label,
@@ -350,7 +352,7 @@ def create(
         "vocals": Track(vocal),
     }
 
-    out = NIStemFile(output, use_alac=use_alac)
+    out = NIStemFile(output, codec)
     out.write(original.read(), {k: v.read() for k, v in stems.items()})
     out.update_metadata(
         mastered if copy_id3tags_from_mastered else None,

--- a/stemgen/__main__.py
+++ b/stemgen/__main__.py
@@ -12,6 +12,7 @@ from .cli import (
     validate_stem_color,
     print_version,
     print_supported_models,
+    enable_verbose_ffmpeg_log_level,
 )
 from .demucs import Demucs
 from .track import Track
@@ -29,6 +30,7 @@ def common_options(func):
         "--verbose",
         default=False,
         is_flag=True,
+        callback=enable_verbose_ffmpeg_log_level,
         help="Display verbose information which may be useful for debugging",
     )
     @click.option(

--- a/stemgen/cli.py
+++ b/stemgen/cli.py
@@ -2,8 +2,9 @@ import click
 import re
 from demucs.api import list_models
 from pathlib import Path
+from torchaudio.utils import ffmpeg_utils
 
-from .constant import MAX_STEM_LABEL_LENGTH
+from .constant import MAX_STEM_LABEL_LENGTH, AvLog
 from . import __version__
 
 
@@ -70,3 +71,8 @@ def print_supported_models(ctx, param, value):
     click.echo("Single models:")
     click.echo("\n    ".join(models["single"]))
     ctx.exit()
+
+
+def enable_verbose_ffmpeg_log_level(ctx, param, value):
+    if value:
+        ffmpeg_utils.set_log_level(AvLog.VERBOSE)

--- a/stemgen/constant.py
+++ b/stemgen/constant.py
@@ -1,5 +1,22 @@
+from enum import IntEnum
+
 SAMPLE_RATE = 44100
 MAX_STEM_LABEL_LENGTH = 32
 
 # Used for file saving
 CHUNK_SIZE = 1_024_000  # 1Mb
+
+
+# See https://ffmpeg.org/doxygen/2.6/group__lavu__log__constants.html
+class AvLog(IntEnum):
+    """ffmpeg Logging Constants"""
+
+    QUIET = -8
+    PANIC = 0
+    FATAL = 8
+    ERROR = 16
+    WARNING = 24
+    INFO = 32
+    VERBOSE = 40
+    DEBUG = 48
+    TRACE = 56

--- a/stemgen/constant.py
+++ b/stemgen/constant.py
@@ -25,3 +25,4 @@ class AvLog(IntEnum):
 class Codec(StrEnum):
     AAC = "aac"
     ALAC = "alac"
+    FLAC = "flac"

--- a/stemgen/constant.py
+++ b/stemgen/constant.py
@@ -1,4 +1,4 @@
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 
 SAMPLE_RATE = 44100
 MAX_STEM_LABEL_LENGTH = 32
@@ -20,3 +20,8 @@ class AvLog(IntEnum):
     VERBOSE = 40
     DEBUG = 48
     TRACE = 56
+
+
+class Codec(StrEnum):
+    AAC = "aac"
+    ALAC = "alac"

--- a/stemgen/constant.py
+++ b/stemgen/constant.py
@@ -1,6 +1,5 @@
 from enum import IntEnum, StrEnum
 
-SAMPLE_RATE = 44100
 MAX_STEM_LABEL_LENGTH = 32
 
 # Used for file saving
@@ -26,3 +25,8 @@ class Codec(StrEnum):
     AAC = "aac"
     ALAC = "alac"
     FLAC = "flac"
+
+
+class SampleRate(IntEnum):
+    Hz44100 = 44100
+    Hz48000 = 48000

--- a/stemgen/constant.py
+++ b/stemgen/constant.py
@@ -25,6 +25,16 @@ class Codec(StrEnum):
     AAC = "aac"
     ALAC = "alac"
     FLAC = "flac"
+    OPUS = "opus"
+
+    def encoder_name(self):
+        # In case of opus, the ffmpeg encoder we want is called "libopus"
+        # There is also one called only "opus", but it is experimental.
+        match self:
+            case Codec.OPUS:
+                return "libopus"
+            case _:
+                return self.value
 
 
 class SampleRate(IntEnum):

--- a/stemgen/demucs.py
+++ b/stemgen/demucs.py
@@ -2,9 +2,6 @@ from demucs.separate import Separator
 import warnings
 
 
-from .constant import SAMPLE_RATE
-
-
 class Demucs:
     def __init__(self, repo, model, device, shifts=1, overlap=0.25, jobs=1):
         self.__separator = Separator(
@@ -24,6 +21,10 @@ class Demucs:
     @property
     def weights(self):
         return self.__separator.model.weights
+
+    @property
+    def sample_rate(self):
+        return self.__separator.samplerate
 
     def callback(self, data):
         if (
@@ -55,7 +56,12 @@ class Demucs:
         )
         with warnings.catch_warnings(record=True) as warn:
             try:
-                return *self.__separator.separate_tensor(samples, SAMPLE_RATE), warn
+                return (
+                    *self.__separator.separate_tensor(
+                        samples, self.__separator.samplerate
+                    ),
+                    warn,
+                )
             finally:
                 update_cb(self.length(samples))
                 finish_cb()

--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -8,7 +8,7 @@ from torchaudio.io import StreamWriter, CodecConfig
 import stembox
 import torch
 
-from .constant import SAMPLE_RATE, CHUNK_SIZE, Codec
+from .constant import CHUNK_SIZE, Codec
 
 logger = logging.getLogger(__file__)
 
@@ -75,26 +75,27 @@ class NIStemFile:
         "#56B4E9",
     ]
 
-    def __init__(self, path, codec: Codec):
-
+    def __init__(
+        self, path, codec: Codec, input_sample_rate: int, output_sample_rate: int
+    ):
         self.__path = path
         self.__codec = codec
         self.__stream = StreamWriter(dst=path, format="mp4")
 
         self.__stream.add_audio_stream(
-            sample_rate=SAMPLE_RATE,
+            sample_rate=input_sample_rate,
             num_channels=2,
             encoder=codec.value,
-            encoder_sample_rate=SAMPLE_RATE,
+            encoder_sample_rate=output_sample_rate,
             encoder_num_channels=2,
             codec_config=CodecConfig(bit_rate=256000),
         )
         for i in range(4):
             self.__stream.add_audio_stream(
-                sample_rate=SAMPLE_RATE,
+                sample_rate=input_sample_rate,
                 num_channels=2,
                 encoder=codec.value,
-                encoder_sample_rate=SAMPLE_RATE,
+                encoder_sample_rate=output_sample_rate,
                 encoder_num_channels=2,
                 codec_config=CodecConfig(bit_rate=256000),
             )

--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -8,7 +8,7 @@ from torchaudio.io import StreamWriter, CodecConfig
 import stembox
 import torch
 
-from .constant import SAMPLE_RATE, CHUNK_SIZE
+from .constant import SAMPLE_RATE, CHUNK_SIZE, Codec
 
 logger = logging.getLogger(__file__)
 
@@ -75,14 +75,16 @@ class NIStemFile:
         "#56B4E9",
     ]
 
-    def __init__(self, path, use_alac=False):
+    def __init__(self, path, codec: Codec):
+
         self.__path = path
+        self.__codec = codec
         self.__stream = StreamWriter(dst=path, format="mp4")
 
         self.__stream.add_audio_stream(
             sample_rate=SAMPLE_RATE,
             num_channels=2,
-            encoder="alac" if use_alac else "aac",
+            encoder=codec.value,
             encoder_sample_rate=SAMPLE_RATE,
             encoder_num_channels=2,
             codec_config=CodecConfig(bit_rate=256000),
@@ -91,7 +93,7 @@ class NIStemFile:
             self.__stream.add_audio_stream(
                 sample_rate=SAMPLE_RATE,
                 num_channels=2,
-                encoder="alac" if use_alac else "aac",
+                encoder=codec.value,
                 encoder_sample_rate=SAMPLE_RATE,
                 encoder_num_channels=2,
                 codec_config=CodecConfig(bit_rate=256000),

--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -113,7 +113,15 @@ class NIStemFile:
 
     def write(self, original, stems):
         sample_count = original.shape[1] + sum([t.shape[1] for t in stems.values()])
-        with self.__stream.open():
+
+        match self.__codec:
+            case Codec.FLAC:
+                # Enable flac muxing in mp4
+                muxer_options = {"strict": "-2"}
+            case _:
+                muxer_options = {}
+
+        with self.__stream.open(option=muxer_options):
             with click.progressbar(
                 length=sample_count, show_percent=True, label="Saving stems"
             ) as progress:

--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -85,7 +85,7 @@ class NIStemFile:
         self.__stream.add_audio_stream(
             sample_rate=input_sample_rate,
             num_channels=2,
-            encoder=codec.value,
+            encoder=codec.encoder_name(),
             encoder_sample_rate=output_sample_rate,
             encoder_num_channels=2,
             codec_config=CodecConfig(bit_rate=256000),
@@ -94,7 +94,7 @@ class NIStemFile:
             self.__stream.add_audio_stream(
                 sample_rate=input_sample_rate,
                 num_channels=2,
-                encoder=codec.value,
+                encoder=codec.encoder_name(),
                 encoder_sample_rate=output_sample_rate,
                 encoder_num_channels=2,
                 codec_config=CodecConfig(bit_rate=256000),

--- a/stemgen/track.py
+++ b/stemgen/track.py
@@ -4,13 +4,11 @@ import logging
 from torch import tensor
 import numpy as np
 
-from .constant import SAMPLE_RATE
-
 logger = logging.getLogger(__file__)
 
 
 class Track:
-    def __init__(self, path):
+    def __init__(self, path: str, sample_rate: int):
         probe = ffmpeg.probe(path)
         self.__stream = [s for s in probe["streams"] if s["codec_type"] == "audio"]
 
@@ -21,6 +19,7 @@ class Track:
 
         self.__stream = self.__stream[0]
         self.__path = path
+        self.__sample_rate = sample_rate
 
     @property
     def audio_channels(self):
@@ -29,7 +28,7 @@ class Track:
     def read(self):
         out, _ = (
             ffmpeg.input(self.__path)
-            .output("-", format="f32le", ar=SAMPLE_RATE, ac=2)
+            .output("-", format="f32le", ar=self.__sample_rate, ac=2)
             .run(capture_stdout=True, capture_stderr=True)
         )
         wav = tensor(np.frombuffer(out, dtype=np.float32))


### PR DESCRIPTION
This adds a bunch of stuff, let me know if you prefer having it in multiple PRs.

## Add verbose ffmpeg logging

During debugging I found this very useful, so I enabled it when `--verbose` is set.

## Multiply progress length by shifts

When demucsing with a shifts value > 1 I noticed that the progress bar was off.
I actually did not look into the demucs code for this, to check if it's correct,
but multiplying by shifts seems to be more accurate than the previous estimation.
I also used the function from the demucs class to get the length to avoid code duplication.

## Make encoder option a string

Instead of having `--use-codec` for each supported encoder, I made this a string option and also added a validation function.

## Add flac

Encoding FLAC results in smaller lossless stem files than ALAC, for me up to 50% in size.
The resulting stem file is read in mixxx without any issues.
For muxing FLAC into MP4 containers, an ffmpeg stricness option needs to set, at least for my ffmpeg version.

## Make output sample rate a parameter, get sample rate from model.

Instead of hard coding the sample rate, it is now read from the demucs model. This theoretically allows usage of models that were trained with different sample rates, although 44.1kHz seems to be the only one I encountered.

More importantly this adds the ability to upsample during encoding for a resulting higher sample rate than the model supports. This is required for opus, since it by design doesn't support 44.1 kHz.

## Add opus

In addition to the aac lossy format, add opus which is royalty free in contrast to aac.
Resulting MP4 files can be read in mixxx without any issue.
Keeping the ffmpeg encoder name `libopus`. ffmpeg also does have an encoder called `opus`, but it gives experimental status warnings.