### PR TITLE
requirements.txt: Switch to tagpy 2025.1 release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 demucs @ git+https://github.com/facebookresearch/demucs.git@583db9df0213ba5f5b3491eca5c993e7629f1949#egg=demucs
-tagpy @ git+https://github.com/acolombier/tagpy.git@7be8801d1079cfb3c3d84839959e954781722eb0#egg=tagpy
+tagpy>=2025.1
 setuptools>=61.0
 ffmpeg-python==0.2.0
 torch>=2.1.2


### PR DESCRIPTION
Currently your main branch of tagpy is used in the `requirements.txt`, with 2 commits on top of an old mainline branch.
https://github.com/acolombier/tagpy/commit/7be8801d1079cfb3c3d84839959e954781722eb0

Since then upstream actually picked one commit from your branch and redid the other.

https://github.com/palfrey/tagpy/commit/153ccf105102718cf945c599fc595ddda2e0abfb
https://github.com/palfrey/tagpy/commit/e7c3a9ed15e7f37efe6f8889abcb7394b1a63d67
https://github.com/palfrey/tagpy/pull/21

This means that all of the required features for stemgen already are upstream and conveniently part of the latest v2025.1 release.

I tested it with stemgen and resulting files do have metadata and covers and look the same in mixxx.