### PR TITLE
Cover improvements

### DIFF
--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -50,14 +50,17 @@ def _extract_cover(f):
         else:
             data = cover.picture()
         mime = cover.mimeType().lower().strip()
-        if "image/jpeg":
-            fmt = tagpy.mp4.CoverArtFormats.JPEG
-        elif "image/png":
-            fmt = tagpy.mp4.CoverArtFormats.PNG
-        elif "image/bmp":
-            fmt = tagpy.mp4.CoverArtFormats.BMP
-        elif "image/gif":
-            fmt = tagpy.mp4.CoverArtFormats.GIF
+        match mime:
+            case "image/jpeg":
+                fmt = tagpy.mp4.CoverArtFormats.JPEG
+            case "image/png":
+                fmt = tagpy.mp4.CoverArtFormats.PNG
+            case "image/bmp":
+                fmt = tagpy.mp4.CoverArtFormats.BMP
+            case "image/gif":
+                fmt = tagpy.mp4.CoverArtFormats.GIF
+            case _:
+                fmt = tagpy.mp4.CoverArtFormats.Unknown
         return tagpy.mp4.CoverArt(fmt, data)
 
 

--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -3,6 +3,7 @@ import click
 import tagpy
 import tagpy.id3v2
 import tagpy.ogg.flac
+import tagpy.mp4
 import logging
 from torchaudio.io import StreamWriter, CodecConfig
 import stembox
@@ -23,11 +24,9 @@ SUPPORTED_TAGS = [
 ]
 
 
-def _extract_cover(f):
-    tag = None
-    if isinstance(f, tagpy.FileRef):
-        tag = f.tag()
-        f = f.file()
+def _extract_cover(file_ref: tagpy.FileRef) -> tagpy.mp4.CoverArt:
+    tag = file_ref.tag()
+    f = file_ref.file()
     covers = []
     if hasattr(tag, "covers"):
         covers = tag.covers

--- a/stemgen/nistemfile.py
+++ b/stemgen/nistemfile.py
@@ -32,6 +32,8 @@ def _extract_cover(file_ref: tagpy.FileRef) -> tagpy.mp4.CoverArt:
         covers = tag.covers
     elif hasattr(tag, "pictureList"):
         covers = tag.pictureList()
+    elif hasattr(f, "pictureList"):
+        covers = f.pictureList()
     elif hasattr(f, "ID3v2Tag") and f.ID3v2Tag():
         covers = [
             a


### PR DESCRIPTION
One very short series, maybe you can get that in before `0.4`.

This mainly adds support for covers in non-Ogg FLAC files, which requires https://github.com/palfrey/tagpy/pull/45 . But it will just do nothing on older tagpy versions.

In addition this fixes one bug where the mime type of covers was not actually checked and improves code style / type annotations.